### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ RKNewsFeedController
 
 A tutorial on how to build a card-based feed like facebook's
 
-##Tutorial / Explanation Link
+## Tutorial / Explanation Link
 https://medium.com/@cwRichardKim/ios-xcode-tutorial-a-card-based-newsfeed-8bedeb7b8df7
 
-##Demo
+## Demo
 ![Imgur](http://i.imgur.com/ciItaIg.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
